### PR TITLE
style: Add diagnostic styles for mobile product grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -257,6 +257,11 @@ body {
 
     .products-grid {
         grid-template-columns: 1fr; /* Consistent for mobile */
+        /* Diagnostic Styles */
+        background-color: rgba(255, 0, 0, 0.5);
+        min-height: 300px;
+        border: 2px solid blue;
+        /* ... any other existing .products-grid rules for mobile ... */
     }
 
     .header {
@@ -270,5 +275,10 @@ body {
     .category-btn { /* From first HTML */
         padding: 0.8rem 0.5rem;
         font-size: 0.7rem;
+    }
+
+    /* Diagnostic Style for product cards on mobile */
+    .product-card {
+        border: 2px solid limegreen !important;
     }
 }


### PR DESCRIPTION
This commit adds temporary diagnostic styles to `styles.css` to help you identify an issue where products are not visible on mobile devices unless "desktop site" mode is enabled.

Specifically, within the `@media (max-width: 768px)` query:
- `.products-grid` now has a semi-transparent red background, a minimum height, and a blue border.
- `.product-card` now has a lime green border (using !important for visibility).

These styles are intended to make the product grid area and individual cards visually prominent on mobile screens to determine if they are rendering and where they are positioned.