### PR TITLE
style: Hide header on mobile for diagnostics

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,11 +4,16 @@
     box-sizing: border-box;
 }
 
+html {
+    height: 100%;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background: linear-gradient(135deg, #4A90E2 0%, #357AE8 100%);
     min-height: 100vh;
     color: #333;
+    overflow-y: auto; /* Added this line */
 }
 
 .header {
@@ -261,8 +266,12 @@ body {
     }
 
     .header {
-        padding: 0.8rem; /* Existing rule */
-        position: static; /* Applied change */
+        display: none; /* Completely hide the header */
+    }
+
+    .container {
+        padding-top: 1rem; /* Add or ensure top padding if header is gone */
+        /* Keep other existing .container mobile styles if any */
     }
 
     .product-info {


### PR DESCRIPTION
This commit updates `styles.css` to further diagnose an issue where product content is not visible on mobile devices.

Changes include:
- Global styles:
    - `html` set to `height: 100%;`
    - `body` now has `overflow-y: auto;` to explicitly enable vertical scrolling.
- Mobile styles (`@media (max-width: 768px)`):
    - The `.header` is now set to `display: none;`, completely removing it from the layout on mobile.
    - Ensured `.container` has top padding.

This is a diagnostic step. If products become visible with the header hidden, it indicates the header's presence (even when static) was contributing to the layout problem.