### PR TITLE
fix(css): Adjust container and grid widths for better layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,7 @@ body {
     flex-grow: 1; /* Added for flex layout */
     overflow-y: auto; /* Added to make container scroll its own content */
     min-height: 0; /* Added to help overflow work with flex-grow */
+    width: 100%; /* Added this line */
 }
 
 .products-grid {
@@ -154,6 +155,7 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 1rem;
     margin-top: 1rem; /* Added from first HTML styles */
+    width: 100%; /* Added this line */
 }
 
 .product-card {


### PR DESCRIPTION
This commit updates `styles.css` to address layout issues that arose after implementing a flexbox body structure:
- Product cards on mobile had extra margins.
- Product grid on desktop was a single centered column.

Changes:
- Added `width: 100%;` to the global `.container` rule. This ensures it attempts to use full available width before being constrained by `max-width` or centered by `margin: auto`.
- Added `width: 100%;` to the global `.products-grid` rule, ensuring it fills the width of the `.container`.

These changes should allow the `repeat(auto-fill, minmax(280px, 1fr))` grid styling to work correctly on desktop and ensure full-width cards (within container padding) on mobile.